### PR TITLE
extArnal mistype fix

### DIFF
--- a/service-kub3/README.md
+++ b/service-kub3/README.md
@@ -83,8 +83,8 @@ status:
 ### Сервисы: ExternalName  
 ```
 kubectl apply -f demo-external-name-svc.yaml
-kubectl get svc -n extarnal-name-svc-app
-kubectl get ep -n extarnal-name-svc-app
+kubectl get svc -n external-name-svc-app
+kubectl get ep -n external-name-svc-app
 kubectl delete -f demo-external-name-svc.yaml
 ```
 

--- a/service-kub3/demo-external-name-svc.yaml
+++ b/service-kub3/demo-external-name-svc.yaml
@@ -2,14 +2,14 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name:  extarnal-name-svc-app
+  name:  external-name-svc-app
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: extarnal-name-svc-app
-  namespace: extarnal-name-svc-app
+  name: external-name-svc-app
+  namespace: external-name-svc-app
 spec:
   type: ExternalName
   externalName: google.com


### PR DESCRIPTION
fixed mistype extArnal in service name inside demo-external-name-svc.yaml, and lesson commands in README.md for lesson service-kub3